### PR TITLE
hiding buttons in bottom bar after household created

### DIFF
--- a/app/src/main/java/com/example/a501_final_project/login_register/HouseholdSetup.kt
+++ b/app/src/main/java/com/example/a501_final_project/login_register/HouseholdSetup.kt
@@ -138,6 +138,9 @@ fun NewHousehold(viewModel: HouseholdViewModel, navController : NavController){
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    if (viewModel.householdCreated) {
+                        return@Row // no need for bottom bar buttons if household already created
+                    }
                     Button(
                         onClick = { viewModel.decrementStep() },
                         enabled = viewModel.setupStep > 0


### PR DESCRIPTION
<img width="540" height="1200" alt="Screenshot_20251203_014442" src="https://github.com/user-attachments/assets/7570d408-2cd6-486f-8754-340d6992a742" />

### Requested feedback
Perhaps it would make sense to move the proceed to app button to the bottom bar. Also might be good to remove the title and change top bar so it is the title instead since they're virtually the same. Thoughts?

### Problem solved
User can no longer try to go back to previous page (was not functional anyways) or continuously create new households like in the video in the issue that this closes.

Closes #60 
